### PR TITLE
own-props-must-be-private detects private identifier (#)

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -11,7 +11,8 @@ export function isPrivate(originalNode: ts.Node) {
       m.kind === ts.SyntaxKind.ProtectedKeyword
     ));
   }
-  return false;
+  // detect private identifier (#)
+  return originalNode.getChildAt(0).kind === SyntaxKind.PrivateIdentifier;
 }
 
 export function getDecorator(node: any, decoratorName?: string): any | any[] {

--- a/tests/lib/rules/own-props-must-be-private/own-props-must-be-private.good.tsx
+++ b/tests/lib/rules/own-props-must-be-private/own-props-must-be-private.good.tsx
@@ -1,6 +1,7 @@
 @Component({ tag: 'sample-tag' })
 export class SampleTag {
   private internalProp: string;
+  #internalProp2: string;
   @OwnDecorator() private internalDecoratedProp: string;
 
   @Prop() readonly test?: string;


### PR DESCRIPTION
Resolves false negatives with the own-props-must-be-private rule when private identifiers (properties prefixed with #) are used instead of the private keyword.

Addresses issue #26 