### PR TITLE
chore(git): add tarball files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 node_modules
 dist
 report
+*.tgz


### PR DESCRIPTION
add the .tgz extension to the gitignore file, as the np package (or,
developers) can generate tarballs during the publish/development
process. this prevents said artifacts from being checked in