### PR TITLE
chore(git): rename primary branch to main

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: Build & Test
 on:
   push:
     branches:
-      - 'master'
+      - 'main'
   pull_request:
     branches:
       - '**'

--- a/README.md
+++ b/README.md
@@ -166,4 +166,4 @@ All contributions welcome.
 
 ## Licence
 
-- [MIT](https://raw.githubusercontent.com/ionic-team/stencil/master/LICENSE)
+- [MIT](https://raw.githubusercontent.com/ionic-team/stencil/main/LICENSE)


### PR DESCRIPTION
update the github workflow to run on 'main' instead of 'master'

update a license link