### PR TITLE
chore(github): add templates for community input

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,46 @@
+name: 🐛 Bug Report
+description: Create a report to help us improve Stencil ESLint
+title: 'bug: '
+body:
+  - type: checkboxes
+    attributes:
+      label: Prerequisites
+      description: Please ensure you have completed all of the following.
+      options:
+        - label: I have read the [Contributing Guidelines](https://github.com/ionic-team/stencil/blob/master/.github/CONTRIBUTING.md).
+          required: true
+        - label: I agree to follow the [Code of Conduct](https://github.com/ionic-team/stencil/blob/master/CODE_OF_CONDUCT.md).
+          required: true
+        - label: I have searched for [existing issues](https://github.com/ionic-team/stencil-eslint/issues) that already report this problem, without success.
+          required: true
+  - type: textarea
+    attributes:
+      label: Stencil ESLint Version
+      description: The version number of Stencil ESLint where the issue is occurring.
+  - type: textarea
+    attributes:
+      label: Current Behavior
+      description: A clear description of what the bug is and how it manifests.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Expected Behavior
+      description: A clear description of what you expected to happen.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Steps to Reproduce
+      description: Please explain the steps required to duplicate this issue.
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: Code Reproduction URL
+      description: Please reproduce this issue in a blank Stencil starter application and provide a link to the repo. Run `npm init stencil` to quickly spin up a Stencil project. This is the best way to ensure this issue is triaged quickly. Issues without a code reproduction may be closed if the Stencil Team cannot reproduce the issue you are reporting.
+      placeholder: https://github.com/...
+  - type: textarea
+    attributes:
+      label: Additional Information
+      description: List any other information that is relevant to your issue. Stack traces, related issues, suggestions on how to fix, Stack Overflow links, forum links, etc.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,13 @@
+contact_links:
+  - name: 📚 Documentation
+    url: https://github.com/ionic-team/stencil-site/issues/new/choose
+    about: This issue tracker is not for documentation issues. Please file documentation issues on the Stencil site repo.
+  - name: 💻 Stencil Compiler
+    url: https://github.com/ionic-team/stencil/issues/new/choose
+    about: This issue tracker is not for Stencil core compiler issues. Please file compiler issues on the Stencil repo.
+  - name: 🛠 Create Stencil CLI
+    url: https://github.com/ionic-team/create-stencil/issues/new/choose
+    about: This issue tracker is not for Create Stencil CLI issues. Please file CLI issues on the Create Stencil CLI repo.
+  - name: 🤔 Support Question
+    url: https://forum.ionicframework.com/
+    about: This issue tracker is not for support questions. Please post your question on the Ionic Forums.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,43 @@
+name: 💡 Feature Request
+description: Suggest an idea for Stencil ESLint
+title: 'feat: '
+body:
+  - type: checkboxes
+    attributes:
+      label: Prerequisites
+      description: Please ensure you have completed all of the following.
+      options:
+        - label: I have read the [Contributing Guidelines](https://github.com/ionic-team/stencil/blob/master/.github/CONTRIBUTING.md).
+          required: true
+        - label: I agree to follow the [Code of Conduct](https://github.com/ionic-team/stencil/blob/master/CODE_OF_CONDUCT.md).
+          required: true
+        - label: I have searched for [existing issues](https://github.com/ionic-team/stencil-eslint/issues) that already include this feature request, without success.
+          required: true
+  - type: textarea
+    attributes:
+      label: Describe the Feature Request
+      description: A clear and concise description of what the feature does.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Describe the Use Case
+      description: A clear and concise use case for what problem this feature would solve.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Describe Preferred Solution
+      description: A clear and concise description of what you how you want this feature to be added to Stencil ESLint.
+  - type: textarea
+    attributes:
+      label: Describe Alternatives
+      description: A clear and concise description of any alternative solutions or features you have considered.
+  - type: textarea
+    attributes:
+      label: Related Code
+      description: If you are able to illustrate the feature request with an example, please provide a sample Stencil component(s), rules, etc. Run `npm init stencil` to quickly spin up a Stencil project.
+  - type: textarea
+    attributes:
+      label: Additional Information
+      description: List any other information that is relevant to your issue. Stack traces, related issues, suggestions on how to implement, Stack Overflow links, forum links, etc.


### PR DESCRIPTION
add templates for bug reports and feature requests. these templates
follow the new beta/v2 version of github's issues & feature requests
templating, respectively.

these were largely copied over from the Stencil compiler repo, with
minor URL adjustments made where necessary. the code of conduct &
contributing guidelines explicitly still point to the Stencil
repository.