### PR TITLE
chore(dependencies): update tsutils

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ npm run lint
 
 - [`@stencil/async-methods`](./docs/async-methods.md)
 
-This rule catches Stencil public methods that are not async.
+This rule catches Stencil public methods decorated with `@Method` that are not async.
 
 - [`@stencil/ban-prefix`](./docs/ban-prefix.md)
 

--- a/docs/async-methods.md
+++ b/docs/async-methods.md
@@ -1,6 +1,6 @@
 # async-methods
 
-Ensures that all `Methods` are `async`.
+Ensures that all `@Methods` are `async`.
 
 ## Config
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7777,9 +7777,9 @@
       "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
     },
     "tsutils": {
-      "version": "3.17.1",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.17.1.tgz",
-      "integrity": "sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==",
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
       "requires": {
         "tslib": "^1.8.1"
       }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "eslint-utils": "^2.0.0",
-    "tsutils": "^3.0.0"
+    "tsutils": "^3.21.0"
   },
   "peerDependencies": {
     "@typescript-eslint/parser": "^2.23.0",


### PR DESCRIPTION
update the minimum dependency on tsutils to v3.21.0

this is a part of the effort to split
https://github.com/ionic-team/stencil-eslint/pull/32 into multiple
commits.

update documentation referencing the `async-methods` rule (which uses
tsutils) to clarify when the rule triggers