### PR TITLE
chore(dependencies): update typescript to v4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7815,9 +7815,9 @@
       }
     },
     "typescript": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
-      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.8.tgz",
+      "integrity": "sha512-oz1765PN+imfz1MlZzSZPtC/tqcwsCyIYA8L47EkRnRW97ztRk83SzMiWLrnChC0vqoYxSU1fcFUDA5gV/ZiPg==",
       "dev": true
     },
     "unique-string": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@typescript-eslint/eslint-plugin": "^2.23.0",
     "eslint-plugin-react": "^7.16.0",
     "eslint": "^6.0.0",
-    "typescript": "^3.8.0"
+    "typescript": "^4.2.4"
   },
   "devDependencies": {
     "@types/eslint": "^6.1.2",
@@ -51,7 +51,7 @@
     "rollup": "^2.0.5",
     "rollup-plugin-node-resolve": "^5.2.0",
     "ts-jest": "^27.0.5",
-    "typescript": "^3.8.0"
+    "typescript": "^4.0.8"
   },
   "engines": {
     "node": ">=8.9.0"


### PR DESCRIPTION
update typescript to v4.0.8. this particular version of typescript was
chosen (as opposed to the latest) to help support all versions of
Stencil 2.x, rather than just the latest version

moving forward, we will only be supporting v2 of Stencil, so I'm marking this as a *breaking change*