### PR TITLE
chore(dependencies): rollup upgrade to v2.58

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1854,9 +1854,9 @@
       "dev": true
     },
     "builtin-modules": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.1.0.tgz",
-      "integrity": "sha512-k0KL0aWZuBt2lrxrcASWDfwOLMnodeQjodT/1SxEQAXsHANgo6ZC/VEaSEHCXt7aSTZ4/4H5LKa+tBXmW7Vtvw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.2.0.tgz",
+      "integrity": "sha512-lGzLKcioL90C7wMczpkY0n/oART3MbBa8R9OFGE1rJxoVI86u4WAGfEk8Wjv10eKSyTHVGkSo3bvBylCEtk7LA==",
       "dev": true
     },
     "builtins": {
@@ -2976,9 +2976,9 @@
       "dev": true
     },
     "fsevents": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
-      "integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "dev": true,
       "optional": true
     },
@@ -7175,12 +7175,12 @@
       }
     },
     "rollup": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.0.5.tgz",
-      "integrity": "sha512-bECGz+RYpw3NYCvLnABu3REUROYbnZsfQZA37ekm/KlgKt/fyxBNN4waBnlLwzx4r6jNBs56SbTn7PEgJjw3fQ==",
+      "version": "2.58.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.58.0.tgz",
+      "integrity": "sha512-NOXpusKnaRpbS7ZVSzcEXqxcLDOagN6iFS8p45RkoiMqPHDLwJm758UF05KlMoCRbLBTZsPOIa887gZJ1AiXvw==",
       "dev": true,
       "requires": {
-        "fsevents": "~2.1.2"
+        "fsevents": "~2.3.2"
       }
     },
     "rollup-plugin-node-resolve": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "jest": "^27.2.4",
     "jest-cli": "^27.2.4",
     "np": "^7.5.0",
-    "rollup": "^2.0.5",
+    "rollup": "^2.58.0",
     "rollup-plugin-node-resolve": "^5.2.0",
     "ts-jest": "^27.0.5",
     "typescript": "^4.0.8"


### PR DESCRIPTION
upgrade rollup to v2.58.0. at the time of this writing, the
rollup-plugin-node-resolve package was completely up to date
and therefore did not warrant an upgrade

this change was tested by running `npm run build && npm pack`, then installing the tarball and other dependencies in a new stencil project. the `--force` flag was required here, as the dependency chain is still in a broken state (and should be fixed once I update eslint).