### PR TITLE
chore(github): add ionitron to repo

### DIFF
--- a/.github/ionic-issue-bot.yml
+++ b/.github/ionic-issue-bot.yml
@@ -1,0 +1,81 @@
+triage:
+  label: triage
+  dryRun: false
+
+closeAndLock:
+  labels:
+    - label: "ionitron: support"
+      message: >
+        Thanks for the issue! This issue appears to be a support request. We use this issue tracker exclusively for
+        bug reports and feature requests. Please use our [slack channel](https://stencil-worldwide.herokuapp.com/)
+        for questions about Stencil.
+
+
+        Thank you for using Stencil!
+    - label: "ionitron: missing template"
+      message: >
+        Thanks for the issue! It appears that you have not filled out the provided issue template. We use this issue
+        template in order to gather more information and further assist you. Please create a new issue and ensure the
+        template is fully filled out.
+
+
+        Thank you for using Stencil!
+  close: true
+  lock: true
+  dryRun: false
+
+noReply:
+  maxIssuesPerRun: 100
+  includePullRequests: false
+  label: Awaiting Reply
+  responseLabel: Reply Received
+  close: false
+  lock: false
+  dryRun: false
+
+stale:
+  days: 180
+  maxIssuesPerRun: 100
+  exemptLabels:
+    - good first issue
+    - help wanted
+    - Reply Received
+    - triage
+  exemptAssigned: true
+  exemptProjects: true
+  exemptMilestones: true
+  label: "ionitron: stale issue"
+  message: >
+    Thanks for the issue! This issue is being closed due to inactivity. If this is still
+    an issue with the latest version of Stencil, please create a new issue and ensure the
+    template is fully filled out.
+
+
+    Thank you for using Stencil!
+  close: true
+  lock: true
+  dryRun: false
+
+wrongRepo:
+  repos:
+    - label: "ionitron: cli"
+      repo: ionic-cli
+      message: >
+        Thanks for the issue! We use this issue tracker exclusively for bug reports and feature requests
+        associated with Stencil. It appears that this issue is associated with the Ionic CLI.
+        I am moving this issue to the Ionic CLI repository. Please track this issue over there.
+
+
+        Thank you for using Stencil!
+    - label: "ionitron: ionic"
+      repo: ionic
+      message: >
+        Thanks for the issue! We use this issue tracker exclusively for bug reports and feature requests
+        associated with Stencil. It appears that this issue is associated with the Ionic Framework.
+        I am moving this issue to the Ionic Framework repository. Please track this issue over there.
+
+
+        Thank you for using Stencil!
+  close: true
+  lock: true
+  dryRun: false


### PR DESCRIPTION


<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Unit tests (`npm test`) were run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): Adding Ionitron to the repo

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
There's not Ionitron automation for labels, adding the triage label, etc.

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
this commit adds ionitron to the repository. to start, this
configuration copies the configuration file that exists in the stencil
core repository today.

all labels mentioned in this configuration file have been manually
created in the repo if they did not already exist


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. -->
we'll just have to monitor this once it goes live. the repo is relatively small, so I don't think that's too much of an ask

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
