### PR TITLE
fix(react): squash react version not specified warning

### DIFF
--- a/src/configs/base.ts
+++ b/src/configs/base.ts
@@ -32,5 +32,13 @@ export default {
         '@stencil/single-export': 2,
       }
     }
-  ]
+  ],
+  settings: {
+    "react": {
+      // intentionally fill the version field with an invalid semver string. this appears to remove the error/warning
+      // emitted to the console when this key/value pair is not in place, but does not tie us to a version of React,
+      // even superficially
+      "version": "stencil-maintainers-put-an-invalid-version-intentionally-if-this-errors-please-raise-an-issue-https://github.com/ionic-team/stencil-eslint/issues",
+    }
+  },
 };


### PR DESCRIPTION




<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
this commit squashes the following warning message that is printed to
the console today:

> Warning: React version not specified in eslint-plugin-react settings.
> See https://github.com/yannickcr/eslint-plugin-react#configuration

because @stencil/eslint uses eslint-plugin-react for JSX related
linting. 

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit puts an invalid semver string in to value field
for the react version. admittedly it's a bit of a hack, but it does
manage to squash the error message.
## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. -->
- Using npm 8, I spun up a new Stencil component library using `npm init stencil`.
- I installed this plugin from the npm registry: `npm i --save-dev @stencil/eslint-plugin  `
- I added the following .eslintrc.json file to the project
  ```json
  {
    "parserOptions": {
        "project": "./tsconfig.json"
    },
    "extends": [
        "plugin:@stencil/recommended"
    ]
}
  ```
- I added the following `lint` script to `package.json`:
`"lint": "eslint src/**/*{.ts,.tsx}"`
- Running `npm run lint` yields the error:
> Warning: React version not specified in eslint-plugin-react settings.
> See https://github.com/yannickcr/eslint-plugin-react#configuration
- Pull down this branch, `npm ci && npm run build && npm pack`
- In the sample component library, install the tarball that was just generated
- `npm run lint` - no more error!
## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
We should look to remove this library/re-evaluate alternatives in the future, but for now this gets one less warning out of the console.