### PR TITLE
Support ESLint 10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
       "peerDependencies": {
         "@typescript-eslint/eslint-plugin": "^7.0.0 || ^8.0.0",
         "@typescript-eslint/parser": "^7.0.0 || ^8.0.0",
-        "eslint": "^8.0.0 || ^9.0.0",
+        "eslint": "^8.0.0 || ^9.0.0 || ^10.0.0",
         "eslint-plugin-react": "^7.37.4",
         "typescript": "^4.9.4 || ^5.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "peerDependencies": {
     "@typescript-eslint/eslint-plugin": "^7.0.0 || ^8.0.0",
     "@typescript-eslint/parser": "^7.0.0 || ^8.0.0",
-    "eslint": "^8.0.0 || ^9.0.0",
+    "eslint": "^8.0.0 || ^9.0.0 || ^10.0.0",
     "eslint-plugin-react": "^7.37.4",
     "typescript": "^4.9.4 || ^5.0.0"
   },

--- a/src/rules/ban-side-effects.ts
+++ b/src/rules/ban-side-effects.ts
@@ -21,7 +21,7 @@ const rule: Rule.RuleModule = {
   },
 
   create(context): Rule.RuleListener {
-    const shouldSkip = /\b(spec|e2e|test)\./.test(context.getFilename());
+    const shouldSkip = /\b(spec|e2e|test)\./.test(context.filename);
     const skipFunctions = context.options[0] || DEFAULTS;
     if (shouldSkip) {
       return {};

--- a/src/rules/own-methods-must-be-private.ts
+++ b/src/rules/own-methods-must-be-private.ts
@@ -46,7 +46,7 @@ const rule: Rule.RuleModule = {
             node: node,
             message: `Own class methods cannot be public`,
             fix(fixer) {
-              const sourceCode = context.getSourceCode();
+              const sourceCode = context.sourceCode;
               const tokens = sourceCode.getTokens(node);
               const publicToken = tokens.find(token => token.value === 'public');
 

--- a/src/rules/own-props-must-be-private.ts
+++ b/src/rules/own-props-must-be-private.ts
@@ -43,7 +43,7 @@ const rule: Rule.RuleModule = {
             node: node,
             message: `Own class properties cannot be public`,
             fix(fixer) {
-              const sourceCode = context.getSourceCode();
+              const sourceCode = context.sourceCode;
               const tokens = sourceCode.getTokens(node);
               const publicToken = tokens.find(token => token.value === 'public');
 


### PR DESCRIPTION
These rules do not work in ESLint 10, because they're using [deprecated members that have been removed from the rule context](https://eslint.org/docs/latest/use/migrate-to-10.0.0#-removal-of-deprecated-context-members).

This PR replaces those uses with their supported alternatives and adds ESLint 10 to the range of versions in `peerDependencies`