### PR TITLE
fix: register enforce-slot-jsdoc and enable it in recommended

### DIFF
--- a/src/configs/recommended.ts
+++ b/src/configs/recommended.ts
@@ -28,6 +28,7 @@ export default {
     'stencil/own-props-must-be-private': 1,
     'stencil/dependency-suggestions': 1,
     'stencil/required-jsdoc': 1,
+    'stencil/enforce-slot-jsdoc': 1,
     "react/jsx-no-bind": [1, {
       "ignoreRefs": true
     }]

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -23,12 +23,14 @@ import banSideEffects from './ban-side-effects';
 import strictBooleanConditions from './strict-boolean-conditions';
 import banExportedConstEnums from './ban-exported-const-enums';
 import dependencySuggestions from './dependency-suggestions';
+import enforceSlotJsdoc from './enforce-slot-jsdoc';
 
 export default {
   'ban-side-effects': banSideEffects,
   'ban-default-true': banDefaultTrue,
   'ban-exported-const-enums': banExportedConstEnums,
   'dependency-suggestions': dependencySuggestions,
+  'enforce-slot-jsdoc': enforceSlotJsdoc,
   'strict-boolean-conditions': strictBooleanConditions,
   'async-methods': asyncMethods,
   'ban-prefix': banPrefix,


### PR DESCRIPTION
`enforce-slot-jsdoc` already exists in the plugin, but it is not registered in the rules index, so consumers cannot actually use it.

This PR wires the rule up and adds it to the recommended config as a warning.

## Changes
- register `enforce-slot-jsdoc` in `src/rules/index.ts`
- enable `stencil/enforce-slot-jsdoc` in `recommended` with warning severity

## Context
I am not sure if there was a specific reason for leaving it out, but it would be useful for us in an upcoming refactor / cleanup effort, so I hope it can be included.