### PR TITLE
fix: Correctly recognize slot names with hyphens.

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,10 @@ This rule catches Stencil decorators in bad locations.
 
 This rule catches Stencil decorators style usage.
 
+- [`stencil/enforce-slot-jsdoc`](./docs/enforce-slot-jsdoc.md)
+
+This rule enforces JSDoc comments for slots in Stencil components.
+
 - [`stencil/element-type`](./docs/element-type.md)
 
 This rule catches Stencil Element decorator have the correct type.
@@ -115,7 +119,7 @@ This rule catches Stencil Methods marked as private or protected.
 
 - [`stencil/no-unused-watch`](./docs/no-unused-watch.md)
 
-This rule catches Stencil Watchs with non existing Props or States.
+This rule catches Stencil Watch decorators for non-existing Props or States.
 
 - [`stencil/own-methods-must-be-private`](./docs/own-methods-must-be-private.md)
 

--- a/src/rules/enforce-slot-jsdoc.ts
+++ b/src/rules/enforce-slot-jsdoc.ts
@@ -26,7 +26,12 @@ const rule: Rule.RuleModule = {
             (jsDocs.length && jsDocs[0].tags.length
               ? jsDocs[0].tags.filter((tag: any) => tag.tagName === "slot")
               : []
-            ).map((tag: any) => tag.comment.split("-")[0].trim() || "<default>")
+            ).map((tag: any) => {
+              // If description has hyphen, it must have a space, see https://jsdoc.app/tags-param
+              const slotCommentParts = tag.comment.split("- ");
+              // If description does not contain hyphen (length == 1), it will be treated as default slot.
+              return slotCommentParts.length > 1 && slotCommentParts[0].trim() ? slotCommentParts[0].trim() : "<default>";
+            })
           );
 
           const missingDocSlots = Array.from(implementedSlots).filter(slot => !documentedSlots.has(slot));

--- a/tests/rules/enforce-slot-jsdoc/enforce-slot-jsdoc.good.tsx
+++ b/tests/rules/enforce-slot-jsdoc/enforce-slot-jsdoc.good.tsx
@@ -1,6 +1,8 @@
 /**
  * @slot - The default slot
+ * @slot Also a valid default slot
  * @slot header - The header slot
+ * @slot side-nav - The side-nav slot (with hyphen/dash in name)
  * @slot footer - The footer slot
  */
 @Component({ tag: 'sample-tag' })
@@ -10,6 +12,7 @@ export class TheSampleTag {
       <div>
         <slot>hello</slot>
         <slot name="header"></slot>
+        <slot name="side-nav"></slot>
         <slot name="footer"></slot>
       </div>
     );


### PR DESCRIPTION
Correctly recognize slot names with hyphens.
Also allow "hyphenless" @slot comments for default slots.

JSDoc docs (https://jsdoc.app/tags-param) state:
"You **can** add a hyphen before the description to make it more readable. **Be sure to include a space before and after the hyphen.**"

I opted to check for "- " instead of " - ", to avoid more complicated checking logic and not cause issues with the "normal" notation `@slot - The default slot`, where the first space is trimmed.
(This would also allow `@slot header- The header slot`)

I added logic to allow doc comment without a leading hyphen still to be allowed and recognized as default slot (as hyphens are optional according to JSDoc, see above)