### PR TITLE
feat: add ESTree fallback for async-methods, render-returns-host, single-export

### DIFF
--- a/src/rules/async-methods.ts
+++ b/src/rules/async-methods.ts
@@ -18,10 +18,12 @@ const rule: Rule.RuleModule = {
   create(context): Rule.RuleListener {
     const stencil = stencilComponentContext();
     const parserServices = context.sourceCode.parserServices;
-    if (!parserServices?.esTreeNodeToTSNodeMap || !parserServices?.program) {
-      return { ...stencil.rules };
+    const hasTypeChecker = parserServices?.esTreeNodeToTSNodeMap && parserServices?.program;
+
+    let typeChecker: ts.TypeChecker | undefined;
+    if (hasTypeChecker) {
+      typeChecker = parserServices.program.getTypeChecker() as ts.TypeChecker;
     }
-    const typeChecker = parserServices.program.getTypeChecker() as ts.TypeChecker;
 
     return {
       ...stencil.rules,
@@ -30,31 +32,48 @@ const rule: Rule.RuleModule = {
           return;
         }
         const node = decoratorNode.parent;
-        const method = parserServices.esTreeNodeToTSNodeMap.get(node);
-        const signature = typeChecker.getSignatureFromDeclaration(method);
-        const returnType = typeChecker.getReturnTypeOfSignature(signature!);
-        if (!isThenableType(typeChecker, method, returnType)) {
-          const originalNode = parserServices.esTreeNodeToTSNodeMap.get(node) as ts.Node;
-          const text = String(originalNode.getFullText());
-          context.report({
-            node: node.key,
-            message: `External @Method() ${node.key.name}() must return a Promise. Consider prefixing the method with async, such as @Method() async ${node.key.name}().`,
-            fix(fixer) {
-              const result = text
-                  // a newline + whitespace preceding `@Method` may be captured, remove it
-                  .trimLeft()
-                  // capture the number of following the decorator to know how far to indent the `async` method
-                  .replace(/@Method\(\)\n(\s*)/, '@Method()\n$1async ')
-                  // replace any inlined @Method decorators
-                  .replace('@Method() ', '@Method() async')
-                  // swap the order of the `async` and `public` keywords
-                  .replace('async public', 'public async')
-                  // swap the order of the `async` and `private` keywords
-                  .replace('async private', 'private async');
-              return fixer.replaceText(node, result);
+
+        // Type-checker path: precise thenable check
+        if (typeChecker && hasTypeChecker) {
+          const method = parserServices.esTreeNodeToTSNodeMap.get(node);
+          const signature = typeChecker.getSignatureFromDeclaration(method);
+          const returnType = typeChecker.getReturnTypeOfSignature(signature!);
+          if (isThenableType(typeChecker, method, returnType)) {
+            return; // OK
+          }
+        } else {
+          // ESTree fallback: check async keyword or Promise return type annotation
+          const functionNode = node.value;
+          if (functionNode?.async) {
+            return; // OK
+          }
+          const returnType = functionNode?.returnType?.typeAnnotation;
+          if (returnType) {
+            // Check for Promise<T> or TSTypeReference with name Promise
+            if (
+              returnType.type === 'TSTypeReference' &&
+              (returnType.typeName?.name === 'Promise' ||
+               returnType.typeName?.right?.name === 'Promise')
+            ) {
+              return; // OK
             }
-          });
+          }
         }
+
+        // Report error with fixer
+        const originalText = context.sourceCode.getText(node);
+        context.report({
+          node: node.key,
+          message: `External @Method() ${node.key.name}() must return a Promise. Consider prefixing the method with async, such as @Method() async ${node.key.name}().`,
+          fix(fixer) {
+            const result = originalText
+                .replace(/@Method\(\)\n(\s*)/, '@Method()\n$1async ')
+                .replace('@Method() ', '@Method() async')
+                .replace('async public', 'public async')
+                .replace('async private', 'private async');
+            return fixer.replaceText(node, result);
+          }
+        });
       }
     };
   }

--- a/src/rules/async-methods.ts
+++ b/src/rules/async-methods.ts
@@ -34,7 +34,7 @@ const rule: Rule.RuleModule = {
         const node = decoratorNode.parent;
 
         // Type-checker path: precise thenable check
-        if (typeChecker && hasTypeChecker) {
+        if (typeChecker) {
           const method = parserServices.esTreeNodeToTSNodeMap.get(node);
           const signature = typeChecker.getSignatureFromDeclaration(method);
           const returnType = typeChecker.getReturnTypeOfSignature(signature!);
@@ -61,6 +61,8 @@ const rule: Rule.RuleModule = {
         }
 
         // Report error with fixer
+        // Note: context.sourceCode.getText() returns only the node's own text (no leading
+        // whitespace), so the trimLeft() call from the old getFullText() approach is not needed.
         const originalText = context.sourceCode.getText(node);
         context.report({
           node: node.key,

--- a/src/rules/render-returns-host.ts
+++ b/src/rules/render-returns-host.ts
@@ -29,10 +29,12 @@ const rule: Rule.RuleModule = {
 
     const stencil = stencilComponentContext();
     const parserServices = context.sourceCode.parserServices;
-    if (!parserServices?.esTreeNodeToTSNodeMap || !parserServices?.program) {
-      return { ...stencil.rules };
+    const hasTypeChecker = parserServices?.esTreeNodeToTSNodeMap && parserServices?.program;
+
+    let typeChecker: ts.TypeChecker | undefined;
+    if (hasTypeChecker) {
+      typeChecker = parserServices.program.getTypeChecker() as ts.TypeChecker;
     }
-    const typeChecker = parserServices.program.getTypeChecker() as ts.TypeChecker;
 
     return {
       ...stencil.rules,
@@ -40,13 +42,26 @@ const rule: Rule.RuleModule = {
         if (!stencil.isComponent()) {
           return;
         }
-        const originalNode = parserServices.esTreeNodeToTSNodeMap.get(node.argument) as ts.MethodDeclaration;
-        const type = typeChecker.getTypeAtLocation(originalNode);
-        if (type && type.symbol && type.symbol.escapedName === 'Array') {
+
+        // ESTree fallback: check if return argument is an ArrayExpression
+        if (node.argument?.type === 'ArrayExpression') {
           context.report({
             node: node,
             message: `Avoid returning an array in the render() function, use <Host> instead.`
           });
+          return;
+        }
+
+        // Type-checker path: resolve type to catch cases where a variable holding an array is returned
+        if (typeChecker && hasTypeChecker) {
+          const originalNode = parserServices.esTreeNodeToTSNodeMap.get(node.argument) as ts.MethodDeclaration;
+          const type = typeChecker.getTypeAtLocation(originalNode);
+          if (type && type.symbol && type.symbol.escapedName === 'Array') {
+            context.report({
+              node: node,
+              message: `Avoid returning an array in the render() function, use <Host> instead.`
+            });
+          }
         }
       }
     };

--- a/src/rules/render-returns-host.ts
+++ b/src/rules/render-returns-host.ts
@@ -43,7 +43,9 @@ const rule: Rule.RuleModule = {
           return;
         }
 
-        // ESTree fallback: check if return argument is an ArrayExpression
+        // ESTree fallback: check if return argument is a literal ArrayExpression (e.g. `return [<A/>, <B/>]`).
+        // This is checked first since it's a zero-cost syntactic test that works with or without type info.
+        // The type-checker path below catches the less common case of a variable holding an array.
         if (node.argument?.type === 'ArrayExpression') {
           context.report({
             node: node,

--- a/src/rules/single-export.ts
+++ b/src/rules/single-export.ts
@@ -72,10 +72,9 @@ const rule: Rule.RuleModule = {
                 exportedValues.push({ node: decl.id, name: decl.id.name });
               }
             }
-          } else if (node.declaration.type === 'TSInterfaceDeclaration' || node.declaration.type === 'TSTypeAliasDeclaration') {
-            // Type-only, skip
-            return;
           }
+          // Note: TSInterfaceDeclaration and TSTypeAliasDeclaration are already excluded
+          // by the exportKind === 'type' check above (typescript-eslint parser marks them as type exports)
         }
         if (node.specifiers) {
           for (const spec of node.specifiers) {

--- a/src/rules/single-export.ts
+++ b/src/rules/single-export.ts
@@ -15,30 +15,98 @@ const rule: Rule.RuleModule = {
 
   create(context): Rule.RuleListener {
     const parserServices = context.sourceCode.parserServices;
-    if (!parserServices?.esTreeNodeToTSNodeMap || !parserServices?.program) {
-      return {};
+    const hasTypeChecker = parserServices?.esTreeNodeToTSNodeMap && parserServices?.program;
+
+    if (hasTypeChecker) {
+      // Type-checker path: uses symbol table for precise export detection
+      const typeChecker = parserServices.program.getTypeChecker() as ts.TypeChecker;
+      return {
+        'ClassDeclaration': (node: any) => {
+          const component = getDecorator(node, 'Component');
+          if (component) {
+            const originalNode = parserServices.esTreeNodeToTSNodeMap.get(node);
+            const nonTypeExports = typeChecker.getExportsOfModule(
+                typeChecker.getSymbolAtLocation(originalNode.getSourceFile())!)
+                .filter(symbol => (symbol.flags & (ts.SymbolFlags.Interface | ts.SymbolFlags.TypeAlias)) === 0)
+                .filter(symbol => symbol.name !== originalNode.name.text);
+
+            nonTypeExports.forEach(symbol => {
+              const errorNode = (symbol.valueDeclaration)
+                  ? parserServices.tsNodeToESTreeNodeMap.get(symbol.valueDeclaration).id
+                  : parserServices.tsNodeToESTreeNodeMap.get(symbol.declarations?.[0]);
+
+              context.report({
+                node: errorNode,
+                message: `To allow efficient bundling, modules using @Component() can only have a single export which is the component class itself. Any other exports should be moved to a separate file. For further information check out: https://stenciljs.com/docs/module-bundling`
+              });
+            });
+          }
+        }
+      };
     }
-    const typeChecker = parserServices.program.getTypeChecker() as ts.TypeChecker;
+
+    // ESTree fallback: find exported value declarations that aren't the @Component class
+    const componentClassNames: Set<string> = new Set();
+    const exportedValues: { node: any; name: string }[] = [];
+
     return {
       'ClassDeclaration': (node: any) => {
         const component = getDecorator(node, 'Component');
-        if (component) {
-          const originalNode = parserServices.esTreeNodeToTSNodeMap.get(node);
-          const nonTypeExports = typeChecker.getExportsOfModule(
-              typeChecker.getSymbolAtLocation(originalNode.getSourceFile())!)
-              .filter(symbol => (symbol.flags & (ts.SymbolFlags.Interface | ts.SymbolFlags.TypeAlias)) === 0)
-              .filter(symbol => symbol.name !== originalNode.name.text);
-
-          nonTypeExports.forEach(symbol => {
-            const errorNode = (symbol.valueDeclaration)
-                ? parserServices.tsNodeToESTreeNodeMap.get(symbol.valueDeclaration).id
-                : parserServices.tsNodeToESTreeNodeMap.get(symbol.declarations?.[0]);
-
-            context.report({
-              node: errorNode,
-              message: `To allow efficient bundling, modules using @Component() can only have a single export which is the component class itself. Any other exports should be moved to a separate file. For further information check out: https://stenciljs.com/docs/module-bundling`
-            });
-          });
+        if (component && node.id) {
+          componentClassNames.add(node.id.name);
+        }
+      },
+      'ExportNamedDeclaration': (node: any) => {
+        // Skip type-only exports
+        if (node.exportKind === 'type') {
+          return;
+        }
+        if (node.declaration) {
+          if (node.declaration.type === 'ClassDeclaration' && node.declaration.id) {
+            exportedValues.push({ node: node.declaration.id, name: node.declaration.id.name });
+          } else if (node.declaration.type === 'FunctionDeclaration' && node.declaration.id) {
+            exportedValues.push({ node: node.declaration.id, name: node.declaration.id.name });
+          } else if (node.declaration.type === 'VariableDeclaration') {
+            for (const decl of node.declaration.declarations) {
+              if (decl.id?.name) {
+                exportedValues.push({ node: decl.id, name: decl.id.name });
+              }
+            }
+          } else if (node.declaration.type === 'TSInterfaceDeclaration' || node.declaration.type === 'TSTypeAliasDeclaration') {
+            // Type-only, skip
+            return;
+          }
+        }
+        if (node.specifiers) {
+          for (const spec of node.specifiers) {
+            if (spec.exportKind === 'type') continue;
+            if (spec.exported?.name) {
+              exportedValues.push({ node: spec.exported, name: spec.exported.name });
+            }
+          }
+        }
+      },
+      'ExportDefaultDeclaration': (node: any) => {
+        if (node.declaration?.id?.name) {
+          exportedValues.push({ node: node.declaration.id, name: node.declaration.id.name });
+        } else {
+          exportedValues.push({ node: node, name: 'default' });
+        }
+      },
+      'Program:exit': () => {
+        if (componentClassNames.size === 0) {
+          return;
+        }
+        // Mimic the type-checker behavior: for each component, report all other exports
+        for (const componentName of componentClassNames) {
+          for (const exported of exportedValues) {
+            if (exported.name !== componentName) {
+              context.report({
+                node: exported.node,
+                message: `To allow efficient bundling, modules using @Component() can only have a single export which is the component class itself. Any other exports should be moved to a separate file. For further information check out: https://stenciljs.com/docs/module-bundling`
+              });
+            }
+          }
         }
       }
     };

--- a/tests/rules/async-methods/async-methods.test.ts
+++ b/tests/rules/async-methods/async-methods.test.ts
@@ -4,6 +4,7 @@ import fs from 'node:fs';
 import { test } from 'vitest';
 
 import { ruleTester } from '../rule-tester';
+import { ruleTesterNoTypeInfo } from '../rule-tester-no-typeinfo';
 import rule from '../../../src/rules/async-methods';
 
 test('async-methods', () => {
@@ -27,6 +28,57 @@ test('async-methods', () => {
         filename: files.wrong,
         errors: 1,
         output: validCode,
+      }
+    ]
+  });
+});
+
+test('async-methods (no type info)', () => {
+  ruleTesterNoTypeInfo.run('async-methods', rule, {
+    valid: [
+      {
+        code: `@Component({ tag: 'sample-tag' })
+export class SampleTag {
+  @Method()
+  async someMethod() {
+    return 'method';
+  }
+  render() { return (<div>test</div>); }
+}`,
+        filename: 'valid-async.tsx'
+      },
+      {
+        code: `@Component({ tag: 'sample-tag' })
+export class SampleTag {
+  @Method()
+  someMethod(): Promise<string> {
+    return Promise.resolve('method');
+  }
+  render() { return (<div>test</div>); }
+}`,
+        filename: 'valid-promise-annotation.tsx'
+      }
+    ],
+    invalid: [
+      {
+        code: `@Component({ tag: 'sample-tag' })
+export class SampleTag {
+  @Method()
+  someMethod() {
+    return 'method';
+  }
+  render() { return (<div>test</div>); }
+}`,
+        filename: 'invalid.tsx',
+        errors: 1,
+        output: `@Component({ tag: 'sample-tag' })
+export class SampleTag {
+  @Method()
+  async someMethod() {
+    return 'method';
+  }
+  render() { return (<div>test</div>); }
+}`
       }
     ]
   });

--- a/tests/rules/async-methods/async-methods.test.ts
+++ b/tests/rules/async-methods/async-methods.test.ts
@@ -57,6 +57,16 @@ export class SampleTag {
   render() { return (<div>test</div>); }
 }`,
         filename: 'valid-promise-annotation.tsx'
+      },
+      {
+        // @Method outside @Component — rule should skip (isComponent() is false)
+        code: `export class NotAComponent {
+  @Method()
+  someMethod() {
+    return 'method';
+  }
+}`,
+        filename: 'valid-not-component.tsx'
       }
     ],
     invalid: [

--- a/tests/rules/render-returns-host/render-returns-host.test.ts
+++ b/tests/rules/render-returns-host/render-returns-host.test.ts
@@ -4,6 +4,7 @@ import fs from 'node:fs';
 import { test } from 'vitest';
 
 import { ruleTester } from '../rule-tester';
+import { ruleTesterNoTypeInfo } from '../rule-tester-no-typeinfo';
 import rule from '../../../src/rules/render-returns-host';
 
 test('render-returns-host', () => {
@@ -23,6 +24,34 @@ test('render-returns-host', () => {
       {
         code: fs.readFileSync(files.wrong, 'utf8'),
         filename: files.wrong,
+        errors: 1
+      }
+    ]
+  });
+});
+
+test('render-returns-host (no type info)', () => {
+  ruleTesterNoTypeInfo.run('render-returns-host', rule, {
+    valid: [
+      {
+        code: `@Component({ tag: 'sample-tag' })
+export class SampleTag {
+  render() {
+    return (<div>test</div>);
+  }
+}`,
+        filename: 'valid.tsx'
+      }
+    ],
+    invalid: [
+      {
+        code: `@Component({ tag: 'sample-tag' })
+export class SampleTag {
+  render() {
+    return [<div>test</div>];
+  }
+}`,
+        filename: 'invalid.tsx',
         errors: 1
       }
     ]

--- a/tests/rules/rule-tester-no-typeinfo.ts
+++ b/tests/rules/rule-tester-no-typeinfo.ts
@@ -1,15 +1,17 @@
+import parser from '@typescript-eslint/parser';
 import { RuleTester } from 'eslint';
 
 /**
- * RuleTester without typescript-eslint parser services.
+ * RuleTester without typescript-eslint parser services (no type info).
  * Simulates environments (e.g. oxlint JS plugin runtime) where
  * esTreeNodeToTSNodeMap and program are unavailable.
  */
 export const ruleTesterNoTypeInfo = new RuleTester({
     languageOptions: {
-        ecmaVersion: 2022,
-        sourceType: 'module',
+        parser,
         parserOptions: {
+            ecmaVersion: 2022,
+            sourceType: 'module',
             ecmaFeatures: {
                 jsx: true
             },

--- a/tests/rules/single-export/single-export.test.ts
+++ b/tests/rules/single-export/single-export.test.ts
@@ -4,6 +4,7 @@ import fs from 'node:fs';
 import { test } from 'vitest';
 
 import { ruleTester } from '../rule-tester';
+import { ruleTesterNoTypeInfo } from '../rule-tester-no-typeinfo';
 import rule from '../../../src/rules/single-export';
 
 test('single-export', () => {
@@ -23,6 +24,64 @@ test('single-export', () => {
       {
         code: fs.readFileSync(files.wrong, 'utf8'),
         filename: files.wrong,
+        errors: 2
+      }
+    ]
+  });
+});
+
+test('single-export (no type info)', () => {
+  ruleTesterNoTypeInfo.run('single-export', rule, {
+    valid: [
+      {
+        code: `@Component({ tag: 'sample-tag' })
+export class SampleTag {
+  render() {
+    return (<div>test</div>);
+  }
+}`,
+        filename: 'valid.tsx'
+      },
+      {
+        // Type exports are allowed
+        code: `@Component({ tag: 'sample-tag' })
+export class SampleTag {
+  render() {
+    return (<div>test</div>);
+  }
+}
+export type SampleProps = { name: string };`,
+        filename: 'valid-type.tsx'
+      }
+    ],
+    invalid: [
+      {
+        code: `@Component({ tag: 'sample-tag' })
+export class SampleTag {
+  render() {
+    return (<div>test</div>);
+  }
+}
+
+export const helper = () => {};`,
+        filename: 'invalid.tsx',
+        errors: 1
+      },
+      {
+        code: `@Component({ tag: 'sample-tag' })
+export class SampleTag {
+  render() {
+    return (<div>test1</div>);
+  }
+}
+
+@Component({ tag: 'sample-other-tag' })
+export class SampleOtherTag {
+  render() {
+    return (<div>test2</div>);
+  }
+}`,
+        filename: 'invalid-two-components.tsx',
         errors: 2
       }
     ]

--- a/tests/rules/single-export/single-export.test.ts
+++ b/tests/rules/single-export/single-export.test.ts
@@ -125,6 +125,19 @@ export default 42;`,
         errors: 1
       },
       {
+        // export default class with id
+        code: `@Component({ tag: 'sample-tag' })
+export class SampleTag {
+  render() {
+    return (<div>test</div>);
+  }
+}
+
+export default class Helper {}`,
+        filename: 'invalid-default-class.tsx',
+        errors: 1
+      },
+      {
         code: `@Component({ tag: 'sample-tag' })
 export class SampleTag {
   render() {

--- a/tests/rules/single-export/single-export.test.ts
+++ b/tests/rules/single-export/single-export.test.ts
@@ -43,7 +43,7 @@ export class SampleTag {
         filename: 'valid.tsx'
       },
       {
-        // Type exports are allowed
+        // Type exports are allowed (export type alias)
         code: `@Component({ tag: 'sample-tag' })
 export class SampleTag {
   render() {
@@ -52,6 +52,22 @@ export class SampleTag {
 }
 export type SampleProps = { name: string };`,
         filename: 'valid-type.tsx'
+      },
+      {
+        // Interface exports are allowed (TSInterfaceDeclaration)
+        code: `@Component({ tag: 'sample-tag' })
+export class SampleTag {
+  render() {
+    return (<div>test</div>);
+  }
+}
+export interface SampleInterface { name: string; }`,
+        filename: 'valid-interface.tsx'
+      },
+      {
+        // No @Component — rule should not report anything
+        code: `export function helper() {}`,
+        filename: 'valid-no-component.tsx'
       }
     ],
     invalid: [
@@ -65,6 +81,47 @@ export class SampleTag {
 
 export const helper = () => {};`,
         filename: 'invalid.tsx',
+        errors: 1
+      },
+      {
+        // Exported function declaration
+        code: `@Component({ tag: 'sample-tag' })
+export class SampleTag {
+  render() {
+    return (<div>test</div>);
+  }
+}
+
+export function helper() {}`,
+        filename: 'invalid-function.tsx',
+        errors: 1
+      },
+      {
+        // Re-export specifier: export { helper }
+        code: `function helper() {}
+
+@Component({ tag: 'sample-tag' })
+export class SampleTag {
+  render() {
+    return (<div>test</div>);
+  }
+}
+
+export { helper };`,
+        filename: 'invalid-specifier.tsx',
+        errors: 1
+      },
+      {
+        // export default expression (no id)
+        code: `@Component({ tag: 'sample-tag' })
+export class SampleTag {
+  render() {
+    return (<div>test</div>);
+  }
+}
+
+export default 42;`,
+        filename: 'invalid-default.tsx',
         errors: 1
       },
       {


### PR DESCRIPTION
These 3 rules previously required TypeScript parser services (esTreeNodeToTSNodeMap + program) and silently skipped in environments without type info (e.g. oxlint JS plugin runtime).

Now they use ESTree-only analysis as a fallback:
- render-returns-host: detects ArrayExpression returns directly
- single-export: counts exported value declarations via AST visitors
- async-methods: checks async keyword or Promise<T> type annotation

The type-checker path is preserved for enhanced precision when available. strict-boolean-conditions remains type-checker-only (no feasible fallback).

Adds no-type-info tests for all 3 rules using ruleTesterNoTypeInfo, with full line coverage on the ESTree fallback paths.