### PR TITLE
fix(enforce-slot-jsdoc): correctly parse hyphenated slot names

### DIFF
--- a/src/rules/enforce-slot-jsdoc.ts
+++ b/src/rules/enforce-slot-jsdoc.ts
@@ -26,7 +26,12 @@ const rule: Rule.RuleModule = {
             (jsDocs.length && jsDocs[0].tags.length
               ? jsDocs[0].tags.filter((tag: any) => tag.tagName === "slot")
               : []
-            ).map((tag: any) => tag.comment.split("-")[0].trim() || "<default>")
+            ).map((tag: any) => {
+              const c = tag.comment.trim();
+              if (!c || c === '-' || c.startsWith('- ')) return '<default>';
+              const idx = c.indexOf(' - ');
+              return idx === -1 ? c : c.slice(0, idx).trim();
+            })
           );
 
           const missingDocSlots = Array.from(implementedSlots).filter(slot => !documentedSlots.has(slot));

--- a/tests/rules/enforce-slot-jsdoc/enforce-slot-jsdoc.hyphenated-wrong.tsx
+++ b/tests/rules/enforce-slot-jsdoc/enforce-slot-jsdoc.hyphenated-wrong.tsx
@@ -1,0 +1,13 @@
+/**
+ * @slot brand - Wrong: only the first segment of the hyphenated slot name
+ */
+@Component({ tag: 'sample-tag' })
+export class TheSampleTag {
+  render() {
+    return (
+      <div>
+        <slot name="brand-bar-logo"></slot>
+      </div>
+    );
+  }
+}

--- a/tests/rules/enforce-slot-jsdoc/enforce-slot-jsdoc.hyphenated.tsx
+++ b/tests/rules/enforce-slot-jsdoc/enforce-slot-jsdoc.hyphenated.tsx
@@ -1,0 +1,19 @@
+/**
+ * @slot - The default slot
+ * @slot brand-bar-logo - The brand bar logo slot
+ * @slot warning-message - The warning message slot
+ * @slot error-message - The error message slot
+ */
+@Component({ tag: 'sample-tag' })
+export class TheSampleTag {
+  render() {
+    return (
+      <div>
+        <slot></slot>
+        <slot name="brand-bar-logo"></slot>
+        <slot name="warning-message"></slot>
+        <slot name="error-message"></slot>
+      </div>
+    );
+  }
+}

--- a/tests/rules/enforce-slot-jsdoc/enforce-slot-jsdoc.test.ts
+++ b/tests/rules/enforce-slot-jsdoc/enforce-slot-jsdoc.test.ts
@@ -11,15 +11,22 @@ test('stencil rules', () => {
     good: path.resolve(__dirname, 'enforce-slot-jsdoc.good.tsx'),
     wrong: path.resolve(__dirname, 'enforce-slot-jsdoc.wrong.tsx'),
     noJsdoc: path.resolve(__dirname, 'enforce-slot-jsdoc.no-jsdoc.tsx'),
+    hyphenated: path.resolve(__dirname, 'enforce-slot-jsdoc.hyphenated.tsx'),
+    hyphenatedWrong: path.resolve(__dirname, 'enforce-slot-jsdoc.hyphenated-wrong.tsx'),
   };
-  const validCode = fs.readFileSync(files.good, 'utf8');
 
   ruleTester.run('enforce-slot-jsdoc', rule, {
     valid: [
       {
-        code: validCode,
-        filename: files.good
-      }
+        code: fs.readFileSync(files.good, 'utf8'),
+        filename: files.good,
+      },
+      {
+        // Hyphenated slot names must be documented using their full name,
+        // not just the segment before the first hyphen.
+        code: fs.readFileSync(files.hyphenated, 'utf8'),
+        filename: files.hyphenated,
+      },
     ],
 
     invalid: [
@@ -32,7 +39,14 @@ test('stencil rules', () => {
         code: fs.readFileSync(files.noJsdoc, 'utf8'),
         filename: files.noJsdoc,
         errors: 2, // <default> and header slots not documented
-      }
+      },
+      {
+        // Documenting only the first segment of a hyphenated slot name
+        // (e.g. @slot brand instead of @slot brand-bar-logo) must not pass.
+        code: fs.readFileSync(files.hyphenatedWrong, 'utf8'),
+        filename: files.hyphenatedWrong,
+        errors: 2, // brand-bar-logo not documented, brand not implemented
+      },
     ]
   });
 });


### PR DESCRIPTION
## Problem

The `enforce-slot-jsdoc` rule parses `@slot` tag names by splitting `tag.comment` on `-` and taking the first segment:

```ts
tag.comment.split("-")[0].trim() || "<default>"
```

This breaks any slot with a hyphenated name. For example, a slot named `brand-bar-logo` documented as `@slot brand-bar-logo - Description` would be read as slot name `brand`, causing false errors on any component that uses hyphenated slot names.

## Fix

Split on ` - ` (space-dash-space) instead, which is the standard JSDoc separator between a tag's name and its description:

```ts
const c = tag.comment.trim();
if (!c || c === '-' || c.startsWith('- ')) return '<default>';
const idx = c.indexOf(' - ');
return idx === -1 ? c : c.slice(0, idx).trim();
```

This preserves existing behaviour for the default slot (`@slot - Description` still resolves to `<default>`) while correctly handling hyphenated names.

## Tests

- Added `enforce-slot-jsdoc.hyphenated.tsx` — valid fixture with hyphenated slot names documented correctly
- Added `enforce-slot-jsdoc.hyphenated-wrong.tsx` — invalid fixture confirming that documenting only the first segment (e.g. `@slot brand` for a slot named `brand-bar-logo`) does not pass